### PR TITLE
Updating search bounds

### DIFF
--- a/app/controllers/hex_grids_controller.rb
+++ b/app/controllers/hex_grids_controller.rb
@@ -8,8 +8,9 @@ class HexGridsController < ApplicationController
     end
 
     # Retrieve the search address from params (pushed from Home) and then retrieve the associated coordinates
-    address = params[:address].gsub(/[^a-zA-Z0-9\s]/, '').gsub(" ", "%20")
-    url = "https://api.mapbox.com/geocoding/v5/mapbox.places/#{address}.json?access_token=#{ENV['MAPBOX_API_KEY']}"
+    address = params[:address]
+    address_formatted = address.gsub(/[^a-zA-Z0-9\s]/, '').gsub(" ", "%20")
+    url = "https://api.mapbox.com/geocoding/v5/mapbox.places/#{address_formatted}.json?access_token=#{ENV['MAPBOX_API_KEY']}"
     uri = URI.parse(url)
     response = Net::HTTP.get_response(uri)
     data = JSON.parse(response.body)

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -28,15 +28,16 @@ export default class extends Controller {
       style: "mapbox://styles/mapbox/streets-v10"
     });
 
-    const searchBounds = [
-      [-0.0100, 51.5545],
-      [-0.0865, 51.5066],
-    ];
+    // Take search coordinates and define a constant Hex Grid & Map load size
+    const centrePoint = this.coordinatesValue
+    const nwPoint = [(centrePoint[0] + 0.03825), (centrePoint[1] + 0.02395)]
+    const sePoint = [(centrePoint[0] - 0.03825), (centrePoint[1] - 0.02395)]
+    const searchBounds = [nwPoint, sePoint]
 
-    // Ensure that the map loads with the correct bounds
+    // Load the map based on search
     this.#boundingBox(searchBounds);
 
-    // Ensure that Hex Grid (and associated functions) is only generated once the map has loaded
+    // Load the Hex Grid (and associated functions) based on search and once map has loaded
     this.map.on("load", () => {
       this.map.setCenter(this.coordinatesValue);
       this.map.setZoom(13);

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -29,7 +29,8 @@ export default class extends Controller {
     });
 
     // Take search coordinates and define a constant Hex Grid & Map load size
-    const centrePoint = this.coordinatesValue
+    let centrePoint = []
+    this.coordinatesValue === null ? centrePoint = [-0.1278, 51.5074] : centrePoint = this.coordinatesValue
     const nwPoint = [(centrePoint[0] + 0.03825), (centrePoint[1] + 0.02395)]
     const sePoint = [(centrePoint[0] - 0.03825), (centrePoint[1] - 0.02395)]
     const searchBounds = [nwPoint, sePoint]

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -11,9 +11,6 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto">
         <% if user_signed_in? %>
-          <li class="nav-item active">
-            <%= link_to "My Map", root_path, class: "nav-link" %>
-          </li>
           <li class="nav-item">
             <%= link_to "My Hives", hives_path, class: "nav-link" %>
           </li>


### PR DESCRIPTION
Details:
- Create a standard Hex Grid size based on search coordinates
- Centre map on Charing Cross with the same Hex Grid size if no coordinates provided
- Removed 'My Map' from navbar as a redundant action